### PR TITLE
removed empty line from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,5 @@
   "dependencies": {
     "react-alert": "^5.5.0",
     "react-alert-template-basic": "^1.0.0"
-
   }
 }


### PR DESCRIPTION
There is an empty line in the package.json file. This leads to an annoying issue whereby after running `npm install` the line is removed but the tracked file in the local repository is indicated to have changed. 

Removing the unneeded line avoids this problem going forward. This is an internal fix - nothing should change for the user.